### PR TITLE
Copy ca-certificates from executing environment into devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/cpp
 {
 	"name": "C++",
+	"initializeCommand": "bash .devcontainer/scripts/copy-certificates.sh",
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04

--- a/.devcontainer/scripts/configure-proxies.sh
+++ b/.devcontainer/scripts/configure-proxies.sh
@@ -113,4 +113,10 @@ if [ "${USE_PROXIES}" = "true" ]; then
     echo "Acquire::https::proxy \"${HTTPS_PROXY}\";" >> /etc/apt/apt.conf
 fi
 
+if [ -n "${http_proxy}" ] || [ -n "${HTTP_PROXY}" ] || [ -n "${https_proxy}" ] || [ -n "${HTTPS_PROXY}" ]; then
+    echo Install ca-certificates from host environment
+    cp -rfu ./.devcontainer/ca-certificates/* -t /usr/local/share/ca-certificates
+    update-ca-certificates
+fi
+
 exit 0

--- a/.devcontainer/scripts/copy-certificates.sh
+++ b/.devcontainer/scripts/copy-certificates.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+# Copyright (c) 2022 Robert Bosch GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if [ -n "${http_proxy}" ] || [ -n "${HTTP_PROXY}" ] || [ -n "${https_proxy}" ] || [ -n "${HTTPS_PROXY}" ]; then
+
+    echo "Proxy configuration found - trying to copy certificates"
+
+    if [ -d /usr/share/ca-certificates ]; then
+        mkdir -p ./.devcontainer/ca-certificates
+        cp -rfu /usr/share/ca-certificates/. -t ./.devcontainer/ca-certificates
+    else
+        echo No folder /usr/share/ca-certificates found.
+    fi
+
+    if [ -d /usr/local/share/ca-certificates ]; then
+        mkdir -p ./.devcontainer/ca-certificates
+        cp -rfu /usr/local/share/ca-certificates/. -t ./.devcontainer/ca-certificates
+    else
+        echo No folder /usr/local/share/ca-certificates found.
+    fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ conan_imports_manifest.txt
 
 # conan home
 .conan_home
+
+# Certificates copied to container
+.devcontainer/ca-certificates/


### PR DESCRIPTION
# Description

During devcontainer build:
* Copy the ca-certificates from executing environment into repos folder under .devcontainer/ca-certificates
  (script `.devcontainer/scripts/copy-certificates.sh` "called" from `devcontainer.json`)
  * **Linux**: Copy everything from /usr/share/ca-certificates and /usr/local/share/ca-certificates
  * **MacOS**: To be tested
  * **Windows**: To be tested 
* Within devcontainer copy the files from there to /usr/local/share/ca-certificates
* Install the certificates using command `update-ca-certificates`
  (in script `.devcontainer/scripts/configure-proxies.sh`)
## Azure DevOps PBI/Task reference

AB#_11472_

## Checklist

* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
