### PR TITLE
Avoid building gRPC on x86_64

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -36,7 +36,7 @@
 |toml|0.10.2|MIT|
 |tqdm|4.64.1|MIT<br/>Mozilla Public License 2.0 (MPL 2.0)|
 |urllib3|1.26.12|MIT|
-|virtualenv|20.16.5|MIT|
+|virtualenv|20.16.6|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,16 +47,6 @@ class VehicleAppCppSdkConan(ConanFile):
         if self.settings.os == "Linux":
             del self.options.fPIC
 
-    def configure(self):
-        # Comment this out for now as we simply want to download the existing package
-        #self.options["grpc"].csharp_plugin = False
-        #self.options["grpc"].node_plugin = False
-        #self.options["grpc"].objective_c_plugin = False
-        #self.options["grpc"].php_plugin = False
-        #self.options["grpc"].python_plugin = False
-        #self.options["grpc"].ruby_plugin = False
-        pass
-
     def layout(self):
         cmake_layout(self, src_folder="sdk")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,12 +48,14 @@ class VehicleAppCppSdkConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        self.options["grpc"].csharp_plugin = False
-        self.options["grpc"].node_plugin = False
-        self.options["grpc"].objective_c_plugin = False
-        self.options["grpc"].php_plugin = False
-        self.options["grpc"].python_plugin = False
-        self.options["grpc"].ruby_plugin = False
+        # Comment this out for now as we simply want to download the existing package
+        #self.options["grpc"].csharp_plugin = False
+        #self.options["grpc"].node_plugin = False
+        #self.options["grpc"].objective_c_plugin = False
+        #self.options["grpc"].php_plugin = False
+        #self.options["grpc"].python_plugin = False
+        #self.options["grpc"].ruby_plugin = False
+        pass
 
     def layout(self):
         cmake_layout(self, src_folder="sdk")


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_11307_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
