### PR TITLE
[Improvement] Extend logger API with support for varargs

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -8,7 +8,7 @@
 |cfgv|3.3.1|MIT|
 |charset-normalizer|2.1.1|MIT|
 |colorama|0.4.6|BSD|
-|conan|1.53.0|MIT|
+|conan|1.54.0|MIT|
 |cpplint|1.6.1|New BSD|
 |distlib|0.3.6|Python Software Foundation License|
 |distro|1.7.0|Apache 2.0|
@@ -23,7 +23,7 @@
 |node-semver|0.6.1|MIT|
 |nodeenv|1.7.0|BSD|
 |patch-ng|1.17.4|MIT|
-|platformdirs|2.5.2|MIT|
+|platformdirs|2.5.3|MIT|
 |pluginbase|1.0.1|BSD|
 |pre-commit|2.20.0|MIT|
 |Pygments|2.13.0|BSD|

--- a/examples/seat-adjuster/src/SeatAdjusterApp.cpp
+++ b/examples/seat-adjuster/src/SeatAdjusterApp.cpp
@@ -71,8 +71,8 @@ void SeatAdjusterApp::onStart() {
 }
 
 void SeatAdjusterApp::onSpeedChanged(const velocitas::DataPointsResult& dataPoints) {
-    velocitas::logger().info(
-        fmt::format("Speed has changed: {}", dataPoints.get(m_vehicleModel->getSpeed())->value()));
+    velocitas::logger().info("Speed has changed: {}",
+                             dataPoints.get(m_vehicleModel->getSpeed())->value());
 }
 
 void SeatAdjusterApp::onSeatMovementRequested(const velocitas::VoidResult& status, int requestId,
@@ -88,7 +88,7 @@ void SeatAdjusterApp::onSeatMovementRequested(const velocitas::VoidResult& statu
 }
 
 void SeatAdjusterApp::onSetPositionRequestReceived(const std::string& data) {
-    velocitas::logger().debug(fmt::format("positionrequest: \"{}\"", data));
+    velocitas::logger().debug("positionrequest: \"{}\"", data);
     const auto jsonData = nlohmann::json::parse(data);
     if (!jsonData.contains(JSON_FIELD_POSITION)) {
         const auto errorMsg = fmt::format("No position specified");
@@ -146,8 +146,8 @@ void SeatAdjusterApp::onSeatPositionChanged(const velocitas::DataPointsResult& d
 
         publishToTopic(TOPIC_CURRENT_POSITION, jsonResponse.dump());
     } catch (std::exception& exception) {
-        velocitas::logger().error(
-            fmt::format("Unable to get Current Seat Position, Exception: {}", exception.what()));
+        velocitas::logger().error("Unable to get Current Seat Position, Exception: {}",
+                                  exception.what());
         nlohmann::json jsonResponse(
             {{JSON_FIELD_STATUS, STATUS_FAIL}, {JSON_FIELD_MESSAGE, exception.what()}});
 
@@ -156,17 +156,16 @@ void SeatAdjusterApp::onSeatPositionChanged(const velocitas::DataPointsResult& d
 }
 
 void SeatAdjusterApp::onError(const velocitas::Status& status) {
-    velocitas::logger().error(
-        fmt::format("Error occurred during async invocation: {}", status.errorMessage()));
+    velocitas::logger().error("Error occurred during async invocation: {}", status.errorMessage());
 }
 
 void SeatAdjusterApp::onErrorDatapoint(const velocitas::Status& status) {
-    velocitas::logger().error(fmt::format("Datapoint: Error occurred during async invocation: {}",
-                                          status.errorMessage()));
+    velocitas::logger().error("Datapoint: Error occurred during async invocation: {}",
+                              status.errorMessage());
 }
 void SeatAdjusterApp::onErrorTopic(const velocitas::Status& status) {
-    velocitas::logger().error(
-        fmt::format("Topic: Error occurred during async invocation: {}", status.errorMessage()));
+    velocitas::logger().error("Topic: Error occurred during async invocation: {}",
+                              status.errorMessage());
 }
 } // namespace example
 

--- a/sdk/include/sdk/Logger.h
+++ b/sdk/include/sdk/Logger.h
@@ -65,6 +65,38 @@ public:
  */
 template <typename TImpl> class Logger {
 public:
+    /**
+     * @brief Proxy function which applies string formatting prior to passing it
+     *        to the actual implementation.
+     */
+    template <typename... T> void info(const std::string& msg, T... args) {
+        info(fmt::format(msg, args...));
+    }
+
+    /**
+     * @brief Proxy function which applies string formatting prior to passing it
+     *        to the actual implementation.
+     */
+    template <typename... T> void warn(const std::string& msg, T... args) {
+        warn(fmt::format(msg, args...));
+    }
+
+    /**
+     * @brief Proxy function which applies string formatting prior to passing it
+     *        to the actual implementation.
+     */
+    template <typename... T> void error(const std::string& msg, T... args) {
+        error(fmt::format(msg, args...));
+    }
+
+    /**
+     * @brief Proxy function which applies string formatting prior to passing it
+     *        to the actual implementation.
+     */
+    template <typename... T> void debug(const std::string& msg, T... args) {
+        debug(fmt::format(msg, args...));
+    }
+
     void info(const std::string& msg) const { m_impl.info(msg); }
     void warn(const std::string& msg) const { m_impl.warn(msg); }
     void error(const std::string& msg) const { m_impl.error(msg); }

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(${TARGET_NAME}
     sdk/ThreadPool.cpp
     sdk/Job.cpp
     sdk/Utils.cpp
+    sdk/Logger.cpp
 
     sdk/dapr/DaprSupport.cpp
     sdk/grpc/GrpcClient.cpp

--- a/sdk/src/sdk/Logger.cpp
+++ b/sdk/src/sdk/Logger.cpp
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) 2022 Robert Bosch GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "sdk/Logger.h"
 
 #include <chrono>

--- a/sdk/src/sdk/Logger.cpp
+++ b/sdk/src/sdk/Logger.cpp
@@ -1,0 +1,44 @@
+#include "sdk/Logger.h"
+
+#include <chrono>
+#include <cstdio>
+#include <fmt/chrono.h>
+#include <fmt/color.h>
+
+namespace velocitas {
+
+/**
+ * @brief Logger implementation for logging to the console.
+ *
+ */
+class ConsoleLogger : public ILogger {
+public:
+    void info(const std::string& msg) override {
+        fmt::print(fmt::fg(fmt::color::white), "{}, INFO  : {}\n", std::chrono::system_clock::now(),
+                   msg);
+        std::fflush(stdout);
+    }
+
+    void warn(const std::string& msg) override {
+        fmt::print(fmt::fg(fmt::color::yellow), "{}, WARN  : {}\n",
+                   std::chrono::system_clock::now(), msg);
+        std::fflush(stdout);
+    }
+
+    void error(const std::string& msg) override {
+        fmt::print(fmt::fg(fmt::color::red), "{}, ERROR : {}\n", std::chrono::system_clock::now(),
+                   msg);
+        std::fflush(stdout);
+    }
+
+    void debug(const std::string& msg) override {
+        fmt::print(fmt::fg(fmt::color::brown), "{}, DEBUG : {}\n", std::chrono::system_clock::now(),
+                   msg);
+        std::fflush(stdout);
+    }
+};
+
+Logger::Logger()
+    : m_impl(std::make_unique<ConsoleLogger>()) {}
+
+} // namespace velocitas

--- a/sdk/src/sdk/Logger.cpp
+++ b/sdk/src/sdk/Logger.cpp
@@ -29,22 +29,14 @@ namespace velocitas {
  */
 class ConsoleLogger : public ILogger {
 public:
-    void info(const std::string& msg) override {
-        log("INFO ", fmt::color::white, msg);
-    }
+    void info(const std::string& msg) override { log("INFO ", fmt::color::white, msg); }
 
-    void warn(const std::string& msg) override {
-        log("WARN ", fmt::color::yellow, msg);
-    }
+    void warn(const std::string& msg) override { log("WARN ", fmt::color::yellow, msg); }
 
-    void error(const std::string& msg) override {
-        log("ERROR", fmt::color::red, msg);
-    }
+    void error(const std::string& msg) override { log("ERROR", fmt::color::red, msg); }
 
-    void debug(const std::string& msg) override {
-        log("DEBUG", fmt::color::brown, msg);
-    }
-    
+    void debug(const std::string& msg) override { log("DEBUG", fmt::color::brown, msg); }
+
 private:
     void log(const std::string& level, fmt::color color, const std::string& msg) {
         fmt::print(fmt::fg(color), "{}, {} : {}\n", std::chrono::system_clock::now(), level, msg);

--- a/sdk/src/sdk/Logger.cpp
+++ b/sdk/src/sdk/Logger.cpp
@@ -30,26 +30,24 @@ namespace velocitas {
 class ConsoleLogger : public ILogger {
 public:
     void info(const std::string& msg) override {
-        fmt::print(fmt::fg(fmt::color::white), "{}, INFO  : {}\n", std::chrono::system_clock::now(),
-                   msg);
-        std::fflush(stdout);
+        log("INFO ", fmt::color::white, msg);
     }
 
     void warn(const std::string& msg) override {
-        fmt::print(fmt::fg(fmt::color::yellow), "{}, WARN  : {}\n",
-                   std::chrono::system_clock::now(), msg);
-        std::fflush(stdout);
+        log("WARN ", fmt::color::yellow, msg);
     }
 
     void error(const std::string& msg) override {
-        fmt::print(fmt::fg(fmt::color::red), "{}, ERROR : {}\n", std::chrono::system_clock::now(),
-                   msg);
-        std::fflush(stdout);
+        log("ERROR", fmt::color::red, msg);
     }
 
     void debug(const std::string& msg) override {
-        fmt::print(fmt::fg(fmt::color::brown), "{}, DEBUG : {}\n", std::chrono::system_clock::now(),
-                   msg);
+        log("DEBUG", fmt::color::brown, msg);
+    }
+    
+private:
+    void log(const std::string& level, fmt::color color, const std::string& msg) {
+        fmt::print(fmt::fg(color), "{}, {} : {}\n", std::chrono::system_clock::now(), level, msg);
         std::fflush(stdout);
     }
 };

--- a/sdk/tests/unit/AsyncResult_tests.cpp
+++ b/sdk/tests/unit/AsyncResult_tests.cpp
@@ -20,13 +20,13 @@
 
 using namespace velocitas;
 
-TEST(AsyncResultTest, await_withBufferedValue_returnsValueImmediately) {
+TEST(Test_AsyncResult, await_withBufferedValue_returnsValueImmediately) {
     AsyncResult<int> asyncResult;
     asyncResult.insertResult(5);
     EXPECT_EQ(5, asyncResult.await());
 }
 
-TEST(AsyncResultTest, await_withoutHandler_blocksCallerUntilResultIsAvailable) {
+TEST(Test_AsyncResult, await_withoutHandler_blocksCallerUntilResultIsAvailable) {
     constexpr auto INT_RESULT{999};
 
     AsyncResult<int> asyncResult;
@@ -41,13 +41,13 @@ TEST(AsyncResultTest, await_withoutHandler_blocksCallerUntilResultIsAvailable) {
     thread.join();
 }
 
-TEST(AsyncResultTest, await_withHandler_throws) {
+TEST(Test_AsyncResult, await_withHandler_throws) {
     AsyncResult<int> asyncResult;
     asyncResult.onResult([](int result) {});
     EXPECT_THROW(asyncResult.await(), std::runtime_error);
 }
 
-TEST(AsyncResultTest, onResult_withRegisteredHandler_handlerCalledWithValue) {
+TEST(Test_AsyncResult, onResult_withRegisteredHandler_handlerCalledWithValue) {
     int              receivedResult{-1};
     AsyncResult<int> asyncResult;
     asyncResult.onResult([&receivedResult](int result) { receivedResult = result; });
@@ -56,7 +56,7 @@ TEST(AsyncResultTest, onResult_withRegisteredHandler_handlerCalledWithValue) {
     EXPECT_EQ(receivedResult, 10);
 }
 
-TEST(AsyncResultTest, onResult_whileAwaiting_throws) {
+TEST(Test_AsyncResult, onResult_whileAwaiting_throws) {
     AsyncResult<int> asyncResult;
     std::thread      thread([&asyncResult]() { asyncResult.await(); });
     while (!asyncResult.isInAwaitingState()) {

--- a/sdk/tests/unit/AsyncSubscription_tests.cpp
+++ b/sdk/tests/unit/AsyncSubscription_tests.cpp
@@ -20,7 +20,7 @@
 
 using namespace velocitas;
 
-TEST(AsyncSubcriptionTest, next_withBufferedItems_returnsItemsInOrder) {
+TEST(Test_AsyncSubcription, next_withBufferedItems_returnsItemsInOrder) {
     AsyncSubscription<int> asyncSubscription;
     asyncSubscription.insertNewItem(1);
     asyncSubscription.insertNewItem(2);
@@ -31,7 +31,7 @@ TEST(AsyncSubcriptionTest, next_withBufferedItems_returnsItemsInOrder) {
     EXPECT_EQ(asyncSubscription.next(), 3);
 }
 
-TEST(AsyncSubcriptionTest, next_noBufferedItems_blocksUntilItemsInserted) {
+TEST(Test_AsyncSubcription, next_noBufferedItems_blocksUntilItemsInserted) {
     constexpr auto         INT_RESULT{999};
     AsyncSubscription<int> asyncSubscription;
     std::thread            thread([&asyncSubscription, INT_RESULT]() {

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${TARGET_NAME}
     AsyncResult_tests.cpp
     AsyncSubscription_tests.cpp
     Job_tests.cpp
+    Logger_tests.cpp
     Node_tests.cpp
     ScopedBoolInverter_tests.cpp
     ThreadPool_tests.cpp

--- a/sdk/tests/unit/Logger_tests.cpp
+++ b/sdk/tests/unit/Logger_tests.cpp
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2022 Robert Bosch GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "sdk/Logger.h"
+
+#include <gtest/gtest.h>
+
+using namespace velocitas;
+
+class StringLogger : public ILogger {
+public:
+    enum class LogLevel { Unknown, Info, Warn, Error, Debug };
+
+    void info(const std::string& msg) override {
+        m_lastLevel   = LogLevel::Info;
+        m_lastMessage = msg;
+    }
+
+    void warn(const std::string& msg) override {
+        m_lastLevel   = LogLevel::Warn;
+        m_lastMessage = msg;
+    }
+
+    void error(const std::string& msg) override {
+        m_lastLevel   = LogLevel::Error;
+        m_lastMessage = msg;
+    }
+
+    void debug(const std::string& msg) override {
+        m_lastLevel   = LogLevel::Debug;
+        m_lastMessage = msg;
+    }
+
+    [[nodiscard]] const std::string& getLogMessage() const { return m_lastMessage; }
+    [[nodiscard]] LogLevel           getLogLevel() const { return m_lastLevel; }
+
+private:
+    std::string m_lastMessage;
+    LogLevel    m_lastLevel{LogLevel::Unknown};
+};
+
+class Test_Logger : public ::testing::Test {
+public:
+    void SetUp() override {
+        auto stringLogger = std::make_unique<StringLogger>();
+        m_stringLogger    = &*stringLogger;
+        logger().setLoggerImplementation(std::move(stringLogger));
+    }
+
+    StringLogger* m_stringLogger{};
+};
+
+TEST_F(Test_Logger, info_withoutArguments_correctMessageLoggedOnCorrectLevel) {
+    logger().info("Hello World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Info);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+}
+
+TEST_F(Test_Logger, info_withArguments_correctMessageLoggedOnCorrectLevel) {
+    const auto testInt   = 1337;
+    const auto testFloat = 9.312F;
+
+    logger().info("Hello {}", "World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Info);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+
+    logger().info("Hello {} {}", "World", testInt);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Info);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World 1337");
+
+    logger().info("{}, {}, {}", "Foo", testInt, testFloat);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Info);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Foo, 1337, 9.312");
+}
+
+TEST_F(Test_Logger, warn_withoutArguments_correctMessageLoggedOnCorrectLevel) {
+    logger().warn("Hello World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Warn);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+}
+
+TEST_F(Test_Logger, warn_withArguments_correctMessageLoggedOnCorrectLevel) {
+    const auto testInt   = 1337;
+    const auto testFloat = 9.312F;
+
+    logger().warn("Hello {}", "World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Warn);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+
+    logger().warn("Hello {} {}", "World", testInt);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Warn);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World 1337");
+
+    logger().warn("{}, {}, {}", "Foo", testInt, testFloat);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Warn);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Foo, 1337, 9.312");
+}
+
+TEST_F(Test_Logger, error_withoutArguments_correctMessageLoggedOnCorrectLevel) {
+    logger().error("Hello World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Error);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+}
+
+TEST_F(Test_Logger, error_withArguments_correctMessageLoggedOnCorrectLevel) {
+    const auto testInt   = 1337;
+    const auto testFloat = 9.312F;
+
+    logger().error("Hello {}", "World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Error);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+
+    logger().error("Hello {} {}", "World", testInt);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Error);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World 1337");
+
+    logger().error("{}, {}, {}", "Foo", testInt, testFloat);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Error);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Foo, 1337, 9.312");
+}
+
+TEST_F(Test_Logger, debug_withoutArguments_correctMessageLoggedOnCorrectLevel) {
+    logger().debug("Hello World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Debug);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+}
+
+TEST_F(Test_Logger, debug_withArguments_correctMessageLoggedOnCorrectLevel) {
+    const auto testInt   = 1337;
+    const auto testFloat = 9.312F;
+
+    logger().debug("Hello {}", "World");
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Debug);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World");
+
+    logger().debug("Hello {} {}", "World", testInt);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Debug);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Hello World 1337");
+
+    logger().debug("{}, {}, {}", "Foo", testInt, testFloat);
+    EXPECT_EQ(m_stringLogger->getLogLevel(), StringLogger::LogLevel::Debug);
+    EXPECT_EQ(m_stringLogger->getLogMessage(), "Foo, 1337, 9.312");
+}

--- a/sdk/tests/unit/Node_tests.cpp
+++ b/sdk/tests/unit/Node_tests.cpp
@@ -19,7 +19,7 @@
 
 using namespace velocitas;
 
-TEST(Node, constructor_withoutParent_isRootNoParent) {
+TEST(Test_Node, constructor_withoutParent_isRootNoParent) {
     Node node{"foo"};
 
     EXPECT_EQ(node.getName(), "foo");
@@ -27,7 +27,7 @@ TEST(Node, constructor_withoutParent_isRootNoParent) {
     EXPECT_EQ(node.getPath(), "foo");
 }
 
-TEST(Node, constructor_withParent_isLeaf) {
+TEST(Test_Node, constructor_withParent_isLeaf) {
     Node nodeRoot{"root"};
     Node node{"foo", &nodeRoot};
 

--- a/sdk/tests/unit/VehicleDataBrokerClient_tests.cpp
+++ b/sdk/tests/unit/VehicleDataBrokerClient_tests.cpp
@@ -20,7 +20,7 @@
 
 using namespace velocitas;
 
-TEST(VehicleDataBrokerClientTest, getDatapoints_noConnection_throwsAsyncException) {
+TEST(Test_VehicleDataBrokerClient, getDatapoints_noConnection_throwsAsyncException) {
     auto client = VehicleDataBrokerClient("my-app-id");
     EXPECT_THROW(client.getDatapoints({})->await(), AsyncException);
 }


### PR DESCRIPTION
# Description

Extends the logger API by adding varargs to the log methods.

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#11167

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [x] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
