### PR TITLE
Remove unnessary call to fmt::format in logging statements

### DIFF
--- a/sdk/include/sdk/grpc/GrpcCall.h
+++ b/sdk/include/sdk/grpc/GrpcCall.h
@@ -66,8 +66,8 @@ private:
                 try {
                     m_onDataHandler(m_reply);
                 } catch (std::exception& e) {
-                    velocitas::logger().error(fmt::format(
-                        "GRPC: Exception occurred during \"GetDatapoints\": {}", e.what()));
+                    velocitas::logger().error(
+                        "GRPC: Exception occurred during \"GetDatapoints\": {}", e.what());
                 }
                 this->StartRead(&m_reply);
             }

--- a/sdk/src/sdk/dapr/DaprSupport.cpp
+++ b/sdk/src/sdk/dapr/DaprSupport.cpp
@@ -40,11 +40,10 @@ void waitForSidecar() {
                 const auto response =
                     cpr::Get(cpr::Url(fmt::format("http://localhost:{}/v1.0/healthz", targetPort)));
                 success = response.status_code == STATUS_NO_CONTENT;
-                logger().debug(fmt::format("dapr: Health endpoint returned status code: {}, {}",
-                                           response.status_code, response.text));
+                logger().debug("dapr: Health endpoint returned status code: {}, {}",
+                               response.status_code, response.text);
             } catch (const std::exception& e) {
-                logger().debug(
-                    fmt::format("dapr: Exception occurred during health endpoint: {}", e.what()));
+                logger().debug("dapr: Exception occurred during health endpoint: {}", e.what());
             }
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }

--- a/sdk/src/sdk/grpc/BrokerAsyncGrpcFacade.cpp
+++ b/sdk/src/sdk/grpc/BrokerAsyncGrpcFacade.cpp
@@ -50,8 +50,8 @@ void BrokerAsyncGrpcFacade::GetDatapoints(
                 errorHandler(status);
             };
         } catch (std::exception& e) {
-            velocitas::logger().error(
-                fmt::format("GRPC: Exception occurred during \"GetDatapoints\": {}", e.what()));
+            velocitas::logger().error("GRPC: Exception occurred during \"GetDatapoints\": {}",
+                                      e.what());
         }
     };
 

--- a/sdk/src/sdk/pubsub/MqttPubSubClient.cpp
+++ b/sdk/src/sdk/pubsub/MqttPubSubClient.cpp
@@ -53,12 +53,12 @@ public:
     bool isConnected() const override { return m_client.is_connected(); }
 
     void publishOnTopic(const std::string& topic, const std::string& data) override {
-        logger().debug(fmt::format(R"(Publish on topic "{}": "{}")", topic, data));
+        logger().debug(R"(Publish on topic "{}": "{}")", topic, data);
         m_client.publish(topic, data)->wait();
     }
 
     AsyncSubscriptionPtr_t<std::string> subscribeTopic(const std::string& topic) override {
-        logger().debug(fmt::format("Subscribing to {}", topic));
+        logger().debug("Subscribing to {}", topic);
         auto subscription = std::make_shared<AsyncSubscription<std::string>>();
         m_subscriberMap.insert(std::make_pair(topic, subscription));
         m_client.subscribe(topic, 0)->wait();
@@ -69,7 +69,7 @@ private:
     void message_arrived(mqtt::const_message_ptr msg) override {
         const std::string& topic   = msg->get_topic();
         const std::string& payload = msg->get_payload_str();
-        logger().debug(fmt::format(R"(MQTT: Update on topic "{}": "{}")", topic, payload));
+        logger().debug(R"(MQTT: Update on topic "{}": "{}")", topic, payload);
 
         // Todo: Replace by solution capable handling wildcards
         auto range = m_subscriberMap.equal_range(topic);


### PR DESCRIPTION
## Describe your changes

Removes unnecessary format invocations in log statements.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [x] Examples are executing successfully
* [x] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [x] Created/updated integration tests.
* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully
* [x] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
