### PR TITLE
Fix Python requirments sync of workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022-2023 Robert Bosch GmbH
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,3 @@
-#!/usr/bin/env bash
-# Copyright (c) 2022 Robert Bosch GmbH
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 gcovr==5.2
 conan==1.58.0
 

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022-2023 Robert Bosch GmbH
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -26,7 +26,7 @@ RUN apk update && \
     apk add linux-headers && \ 
     apk add perl && \
     apk add bash && \
-    pip3 install conan
+    pip3 install "conan==1.58"
 
 COPY . /sdk
 


### PR DESCRIPTION
## Describe your changes

Fix for commit "Use Python requirements.txt for CI workflow also (#38)":
SDK - Build Base Container workflow was not regarded

## Issue ticket number and link

none

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
