### PR TITLE
fix: Dynamic versioning should cut off initial v on prefixed semver

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,6 +16,7 @@ from conans import ConanFile, tools
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 import subprocess
 import os
+import re
 
 class VehicleAppCppSdkConan(ConanFile):
     name = "vehicle-app-sdk"
@@ -55,7 +56,13 @@ class VehicleAppCppSdkConan(ConanFile):
     def set_version(self):
         try:
             git = tools.Git(folder=".")
-            version = git.get_tag() if git.get_tag() is not None else git.get_branch()
+            tag = git.get_tag()
+            if tag is not None:
+                version_tag_pattern = re.compile(r"^v[0-9]+(\.[0-9]+){0,2}$")
+                if version_tag_pattern.match(tag):
+                    tag = tag[1:] # cut off initial v if a semver tag
+
+            version = tag if tag is not None else git.get_branch()
             if version == "HEAD (no branch)":
                 version = git.get_commit()
             open("./version.txt", mode="w", encoding="utf-8").write(version)


### PR DESCRIPTION
## Describe your changes

Cut off initial v on tags if they represent a semver.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
