### PR TITLE
fix: Pin zlib version b/c of conflicts in dependencies

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -12,10 +12,10 @@
 |cpplint|1.6.1|New BSD|
 |distlib|0.3.7|Python Software Foundation License|
 |distro|1.8.0|Apache 2.0|
-|fasteners|0.18|Apache 2.0|
+|fasteners|0.19|Apache 2.0|
 |filelock|3.12.4|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.5.28|MIT|
+|identify|2.5.29|MIT|
 |idna|3.4|BSD|
 |Jinja2|3.1.2|New BSD|
 |lxml|4.9.3|New BSD|

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -64,4 +64,4 @@ they are given here (manually added) for time being:
 |paho-mqtt-cpp|1.2.0|EPL 1.0 AND EDL 1.0|
 |protobuf|3.21.9|Google License|
 |re2|20220601|BSD-3-Clause|
-|zlib|1.2.13|zlib/libpng license|
+|zlib|1.3|zlib/libpng license|

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,8 @@ class VehicleAppCppSdkConan(ConanFile):
         ("openssl/1.1.1u@#de76bbea24d8b46f8def8daa18b31fd9"),
         ("paho-mqtt-c/1.3.9@#0421671a9f4e8ccfa5fc678cfb160394"),
         ("paho-mqtt-cpp/1.2.0@#cb70f45760e60655faa35251a394b1d2"),
-        ("protobuf/3.21.9@#515ceb0a1653cf84363d9968b812d6be")
+        ("protobuf/3.21.9@#515ceb0a1653cf84363d9968b812d6be"),
+        ("zlib/1.3")
     ]
     generators = "cmake"
     author = "Robert Bosch GmbH"


### PR DESCRIPTION
## Describe your changes

Conflict in grpc/1.50.1:
    'grpc/1.50.1' requires 'zlib/1.2.13' while 'protobuf/3.21.9' requires 'zlib/1.3'.

Therefore, zlib needs to be fixed on SDK level.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
