### PR TITLE
fix: Use gcc 11 in app builder

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -14,7 +14,7 @@
 
 # syntax = docker/dockerfile:1.3
 
-FROM alpine:3.18.3
+FROM alpine:3.16.0
 
 RUN apk update && \
     apk add ninja && \


### PR DESCRIPTION
## Describe your changes

The late upgrade to alpine 18 caused the gcc compiler to get a version bump to 12 which is not supported (yet) by the app template. This PR downgrades alpine again to revert back to gcc 11.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
