### PR TITLE
Enable URL parsing from env variables of middleware config

### DIFF
--- a/sdk/include/sdk/Utils.h
+++ b/sdk/include/sdk/Utils.h
@@ -79,6 +79,51 @@ private:
     StringUtils() = delete;
 };
 
+/**
+ * @brief Provides a simplified URL parser.
+ *
+ * It is able to parse just URL starting with a "://" behind the scheme
+ * specifier, e.g. "http://somehost:1234/somePath", but not URLs like
+ * "mailto:receipient@somewhere.io".
+ * As an advantage it can handle "URLs" without leading scheme, like
+ * "//127.0.0.1:42" or "localhost:123".
+ * Currently it just provides access to the scheme and the network location
+ * ("login") part of the URL.
+ * Other elements to be added as needed ...
+ */
+class SimpleUrlParse {
+public:
+    /**
+     * @brief Construct a new Simple Url Parse object
+     *
+     * @param url to be parsed
+     */
+    SimpleUrlParse(const std::string& url);
+
+    /**
+     * @brief Get the scheme of the parsed URL
+     *
+     * @return std::string Parsed scheme which can be the empty string if the
+     *         URL does not contain a scheme
+     */
+    [[nodiscard]] std::string getScheme() const { return m_scheme; }
+
+    /**
+     * @brief Get the network location part of the parsed URL
+     *
+     * This is the part between the leading double slashes and the first slash after,
+     * e.g. URL = "http://username:password@hostname:portnumber/path"
+     * --> netLocation = "username:password@hostname:portnumber"
+     *
+     * @return std::string
+     */
+    [[nodiscard]] std::string getNetLocation() const { return m_netLocation; }
+
+private:
+    std::string m_scheme;
+    std::string m_netLocation;
+};
+
 } // namespace velocitas
 
 #endif // VEHICLE_APP_SDK_UTILS_H

--- a/sdk/include/sdk/middleware/Middleware.h
+++ b/sdk/include/sdk/middleware/Middleware.h
@@ -51,7 +51,7 @@ public:
      *
      * @return std::string type of the middleware
      */
-    std::string getTypeId() const { return m_typeId; }
+    [[nodiscard]] std::string getTypeId() const { return m_typeId; }
 
     /**
      * @brief Triggers the start of the middleware
@@ -73,7 +73,7 @@ public:
      * @return std::string representing the location description
      * @throws std::runtime_error if the service location cannot be determined
      */
-    virtual std::string getServiceLocation(const std::string& serviceName) const = 0;
+    [[nodiscard]] virtual std::string getServiceLocation(const std::string& serviceName) const = 0;
 
     /**
      * @brief Generic type for middleware specific metadata     *
@@ -86,7 +86,7 @@ public:
      * @param serviceName Name of the service to communicate with
      * @return Metadata
      */
-    virtual Metadata getMetadata(const std::string& serviceName) const {
+    [[nodiscard]] virtual Metadata getMetadata(const std::string& serviceName) const {
         std::ignore = serviceName;
         return Metadata{};
     }
@@ -97,7 +97,7 @@ public:
      * @param clientId
      * @return std::shared_ptr<IPubSubClient>
      */
-    virtual std::shared_ptr<IPubSubClient>
+    [[nodiscard]] virtual std::shared_ptr<IPubSubClient>
     createPubSubClient(const std::string& clientId) const = 0;
 
 protected:

--- a/sdk/src/sdk/Utils.cpp
+++ b/sdk/src/sdk/Utils.cpp
@@ -54,4 +54,28 @@ std::string StringUtils::join(const std::vector<std::string>& stringVector,
     return oss.str();
 }
 
+namespace {
+const std::string SCHEME_PART_START           = "//";
+const std::string SIMPLIFIED_SCHEME_SEPARATOR = "://";
+} // namespace
+
+SimpleUrlParse::SimpleUrlParse(const std::string& url) {
+    auto schemeLen = url.find(SIMPLIFIED_SCHEME_SEPARATOR);
+    if (schemeLen != std::string::npos) {
+        m_scheme = StringUtils::toLower(url.substr(0, schemeLen));
+    } else {
+        schemeLen = 0;
+    }
+
+    auto startOfSchemePart = url.find(SCHEME_PART_START, schemeLen);
+    if (startOfSchemePart != std::string::npos) {
+        startOfSchemePart += SCHEME_PART_START.length();
+    } else {
+        startOfSchemePart = 0;
+    }
+
+    auto netLocationLen = url.find("/", startOfSchemePart) - startOfSchemePart;
+    m_netLocation       = url.substr(startOfSchemePart, netLocationLen);
+}
+
 } // namespace velocitas

--- a/sdk/src/sdk/middleware/NativeMiddleware.cpp
+++ b/sdk/src/sdk/middleware/NativeMiddleware.cpp
@@ -38,7 +38,7 @@ static std::string getDefaultLocation(const std::string& serviceName) {
     std::string defaultLocation;
     auto        iter = DEFAULT_LOCATIONS.find(StringUtils::toLower(serviceName));
     if (iter != DEFAULT_LOCATIONS.end()) {
-        defaultLocation = iter->second;
+        defaultLocation = SimpleUrlParse(iter->second).getNetLocation();
     }
     return defaultLocation;
 };
@@ -49,16 +49,16 @@ static std::string getServiceEnvVarName(const std::string& serviceName) {
 
 std::string NativeMiddleware::getServiceLocation(const std::string& serviceName) const {
     auto envVarName     = getServiceEnvVarName(serviceName);
-    auto serviceAddress = getEnvVar(envVarName);
+    auto serviceAddress = SimpleUrlParse(getEnvVar(envVarName)).getNetLocation();
     if (!serviceAddress.empty()) {
         return serviceAddress;
     }
 
     serviceAddress = getDefaultLocation(serviceName);
     if (!serviceAddress.empty()) {
-        logger().warn(
-            "Env variable '{}' defining location of service '{}' not set. Taking default: '{}'",
-            envVarName, serviceName, serviceAddress);
+        logger().warn("Env variable '{}' defining location of service '{}' not properly set. "
+                      "Taking default: '{}'",
+                      envVarName, serviceName, serviceAddress);
         return serviceAddress;
     }
 

--- a/sdk/tests/unit/NativeMiddleware_tests.cpp
+++ b/sdk/tests/unit/NativeMiddleware_tests.cpp
@@ -44,10 +44,21 @@ TEST_F(Test_NativeMiddleware, getServiceLocation_envVarNotSet_throwsRuntimeError
     EXPECT_THROW(getCut().getServiceLocation("UnknownService"), std::runtime_error);
 }
 
-TEST_F(Test_NativeMiddleware, getServiceLocation_envVarSet_contentOfEnvVar) {
+TEST_F(Test_NativeMiddleware, getServiceLocation_envVarNotSetButDefaultKnown_default) {
+    auto serviceLocation = getCut().getServiceLocation("mqtt");
+    EXPECT_EQ("localhost:1883", serviceLocation);
+}
+
+TEST_F(Test_NativeMiddleware, getServiceLocation_envVarSetWithPureAddress_contentOfEnvVar) {
     setEnvVar("SDV_SOMESERVICE_ADDRESS", "some-service-address");
     auto serviceLocation = getCut().getServiceLocation("SomeService");
     EXPECT_EQ("some-service-address", serviceLocation);
+}
+
+TEST_F(Test_NativeMiddleware, getServiceLocation_envVarSetWithUrl_contentOfUrlsNetLocation) {
+    setEnvVar("SDV_SOMESERVICE_ADDRESS", "scheme://some-host:port/path");
+    auto serviceLocation = getCut().getServiceLocation("SomeService");
+    EXPECT_EQ("some-host:port", serviceLocation);
 }
 
 TEST_F(Test_NativeMiddleware, getMetadata__emptyMap) {

--- a/sdk/tests/unit/Utils_tests.cpp
+++ b/sdk/tests/unit/Utils_tests.cpp
@@ -27,13 +27,13 @@ TEST(Utils, getEnvVar_varNotSet_defaultValue) {
 }
 
 TEST(Utils, getEnvVar_emptyVar_emptyString) {
-    ::setenv("MY_TEST_ENV_VAR", "", /*overwrite=*/true);
+    ::setenv("MY_TEST_ENV_VAR", "", /*overwrite=*/1);
     std::string varContent = getEnvVar("MY_TEST_ENV_VAR", "default content");
     EXPECT_EQ("", varContent);
 }
 
 TEST(Utils, getEnvVar_nonEmptyVar_varContent) {
-    ::setenv("MY_TEST_ENV_VAR", "some content", /*overwrite=*/true);
+    ::setenv("MY_TEST_ENV_VAR", "some content", /*overwrite=*/1);
     std::string varContent = getEnvVar("MY_TEST_ENV_VAR", "default content");
     EXPECT_EQ("some content", varContent);
 }
@@ -78,4 +78,46 @@ TEST(StringUtils, join_vectorWithMultipleElements_elementsJoinedWithSeparator) {
     std::vector<std::string> v      = {"foo", "bar", "baz"};
     auto                     result = StringUtils::join(v, ",");
     EXPECT_EQ(result, "foo,bar,baz");
+}
+
+TEST(SimpleUrlParse, emptyString) {
+    SimpleUrlParse cut("");
+    EXPECT_EQ("", cut.getScheme());
+    EXPECT_EQ("", cut.getNetLocation());
+}
+
+TEST(SimpleUrlParse, noScheme_noSlashes_hostname_noPort_noPath) {
+    SimpleUrlParse cut("localhost");
+    EXPECT_EQ("", cut.getScheme());
+    EXPECT_EQ("localhost", cut.getNetLocation());
+}
+
+TEST(SimpleUrlParse, noScheme_noSlashes_ipAddress_noPort_noPath) {
+    SimpleUrlParse cut("1.2.3.4");
+    EXPECT_EQ("", cut.getScheme());
+    EXPECT_EQ("1.2.3.4", cut.getNetLocation());
+}
+
+TEST(SimpleUrlParse, ctor_noScheme_slashes_hostname_port_noPath) {
+    SimpleUrlParse cut("//localhost:42");
+    EXPECT_EQ("", cut.getScheme());
+    EXPECT_EQ("localhost:42", cut.getNetLocation());
+}
+
+TEST(SimpleUrlParse, ctor_noScheme_slashes_user_password_hostname_port_noPath) {
+    SimpleUrlParse cut("//username:password@localhost:42");
+    EXPECT_EQ("", cut.getScheme());
+    EXPECT_EQ("username:password@localhost:42", cut.getNetLocation());
+}
+
+TEST(SimpleUrlParse, ctor_someScheme_slashes_user_password_hostname_port_emptyPath) {
+    SimpleUrlParse cut("WhatEver://username:password@localhost:42/");
+    EXPECT_EQ("whatever", cut.getScheme());
+    EXPECT_EQ("username:password@localhost:42", cut.getNetLocation());
+}
+
+TEST(SimpleUrlParse, ctor_someScheme_slashes_ipAddress_noPort_pathAndQuery) {
+    SimpleUrlParse cut("SomeScheme://1.2.3.4/somePath?query");
+    EXPECT_EQ("somescheme", cut.getScheme());
+    EXPECT_EQ("1.2.3.4", cut.getNetLocation());
 }


### PR DESCRIPTION
## Describe your changes

This improvement enables to parse URL-like addresses (e.g. `mqtt://localhost:1883`) from the environment variables used to configure communication partners of applications, like `SDV_MQTT_ADDRESS`.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
