### PR TITLE
[#93] Fix logger formatting issue for enum class Failure with libfmt 10.x

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -13,7 +13,7 @@
 |distlib|0.3.8|Python Software Foundation License|
 |distro|1.8.0|Apache 2.0|
 |fasteners|0.19|Apache 2.0|
-|filelock|3.15.1|The Unlicense (Unlicense)|
+|filelock|3.15.4|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
 |identify|2.5.36|MIT|
 |idna|3.7|BSD|
@@ -34,7 +34,7 @@
 |six|1.16.0|MIT|
 |tqdm|4.66.4|MIT<br/>Mozilla Public License 2.0 (MPL 2.0)|
 |urllib3|1.26.19|MIT|
-|virtualenv|20.26.2|MIT|
+|virtualenv|20.26.3|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/sdk/src/sdk/grpc/GrpcDataPointValueProvider.cpp
+++ b/sdk/src/sdk/grpc/GrpcDataPointValueProvider.cpp
@@ -42,7 +42,7 @@ DataPointValue::Failure GrpcDataPointValueProvider::getFailure() const {
     case sdv::databroker::v1::Datapoint_Failure_INTERNAL_ERROR:
         return DataPointValue::Failure::INTERNAL_ERROR;
     default:
-        logger().error("Unknown 'DataPointValue::Failure': {}", m_datapoint.failure_value());
+        logger().error("Unknown 'DataPointValue::Failure': {}", static_cast<int>(m_datapoint.failure_value()));
         assert(false);
         return DataPointValue::Failure::INTERNAL_ERROR;
     }

--- a/sdk/src/sdk/grpc/GrpcDataPointValueProvider.cpp
+++ b/sdk/src/sdk/grpc/GrpcDataPointValueProvider.cpp
@@ -30,6 +30,10 @@ const sdv::databroker::v1::Datapoint& GrpcDataPointValueProvider::getDataPoint()
 }
 
 DataPointValue::Failure GrpcDataPointValueProvider::getFailure() const {
+    if (!m_datapoint.has_failure_value()) {
+        return DataPointValue::Failure::NONE;
+    }
+
     switch (m_datapoint.failure_value()) {
     case sdv::databroker::v1::Datapoint_Failure_INVALID_VALUE:
         return DataPointValue::Failure::INVALID_VALUE;


### PR DESCRIPTION
…v10.2.1

<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
## Describe your changes
Fixed a logging issue related to Failure enum values for libfmt v10.x. Updated the logging statement to correctly handle the Failure enum value by converting it to an integer representation (static_cast<int>(...)) before logging it. This ensures the logger formats enum values correctly and aligns with the requirements of libfmt v10.x

<!--
Please provide a brief description to what your change does.
-->

## Issue ticket number and link
Ticket No : #93 
<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [x] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas Docs)
