### PR TITLE
Update examples to VSS release 4

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -15,7 +15,7 @@
 |fasteners|0.19|Apache 2.0|
 |filelock|3.15.4|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.5.36|MIT|
+|identify|2.6.0|MIT|
 |idna|3.7|BSD|
 |jinja2|3.1.4|BSD|
 |lxml|5.2.2|New BSD|

--- a/examples/example_model/vehicle/Cabin/Cabin.h
+++ b/examples/example_model/vehicle/Cabin/Cabin.h
@@ -35,28 +35,15 @@ public:
     public:
         class RowType : public ParentClass {
         public:
-            RowType(const std::string& name, ParentClass* parent)
+            RowType(std::string name, ParentClass* parent)
                 : ParentClass(name, parent)
-                , Pos1("Pos1", this)
-                , Pos2("Pos2", this)
-                , Pos3("Pos3", this) {}
+                , DriverSide("DriverSide", this)
+                , Middle("Middle", this)
+                , PassengerSide("PassengerSide", this) {}
 
-            vehicle::cabin::Seat& Pos(int index) {
-                if (index == 1) {
-                    return Pos1;
-                }
-                if (index == 2) {
-                    return Pos2;
-                }
-                if (index == 3) {
-                    return Pos3;
-                }
-                throw std::runtime_error("Given value is outside of allowed range [1;3]!");
-            }
-
-            vehicle::cabin::Seat Pos1;
-            vehicle::cabin::Seat Pos2;
-            vehicle::cabin::Seat Pos3;
+            vehicle::cabin::Seat DriverSide;
+            vehicle::cabin::Seat Middle;
+            vehicle::cabin::Seat PassengerSide;
         };
 
         explicit SeatCollection(ParentClass* parent)

--- a/examples/example_model/vehicle/Cabin/Cabin.h
+++ b/examples/example_model/vehicle/Cabin/Cabin.h
@@ -35,7 +35,7 @@ public:
     public:
         class RowType : public ParentClass {
         public:
-            RowType(std::string name, ParentClass* parent)
+            RowType(const std::string& name, ParentClass* parent)
                 : ParentClass(name, parent)
                 , DriverSide("DriverSide", this)
                 , Middle("Middle", this)

--- a/examples/seat-adjuster/AppManifest.json
+++ b/examples/seat-adjuster/AppManifest.json
@@ -5,11 +5,11 @@
         {
             "type": "vehicle-signal-interface",
             "config": {
-                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
+                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v4.0/vss_rel_4.0.json",
                 "datapoints": {
                     "required": [
                         {
-                            "path": "Vehicle.Cabin.Seat.Row1.Pos1.Position",
+                            "path": "Vehicle.Cabin.Seat.Row1.DriverSide.Position",
                             "access": "write"
                         },
                         {

--- a/examples/seat-adjuster/src/SeatAdjusterApp.cpp
+++ b/examples/seat-adjuster/src/SeatAdjusterApp.cpp
@@ -48,7 +48,8 @@ void SeatAdjusterApp::onStart() {
     velocitas::logger().info("Subscribe for data points!");
 
     subscribeDataPoints(
-        velocitas::QueryBuilder::select(m_vehicleModel->Cabin.Seat.Row1.Pos1.Position).build())
+        velocitas::QueryBuilder::select(m_vehicleModel->Cabin.Seat.Row1.DriverSide.Position)
+            .build())
         ->onItem([this](auto&& item) { onSeatPositionChanged(std::forward<decltype(item)>(item)); })
         ->onError(
             [this](auto&& status) { onErrorDatapoint(std::forward<decltype(status)>(status)); });
@@ -80,7 +81,7 @@ void SeatAdjusterApp::onSetPositionRequestReceived(const std::string& data) {
     nlohmann::json respData({{JSON_FIELD_REQUEST_ID, requestId}, {JSON_FIELD_RESULT, {}}});
     const auto     vehicleSpeed = m_vehicleModel->Speed.get()->await().value();
     if (vehicleSpeed == 0) {
-        m_vehicleModel->Cabin.Seat.Row1.Pos1.Position.set(desiredSeatPosition)->await();
+        m_vehicleModel->Cabin.Seat.Row1.DriverSide.Position.set(desiredSeatPosition)->await();
 
         respData[JSON_FIELD_RESULT][JSON_FIELD_STATUS] = STATUS_OK;
         respData[JSON_FIELD_RESULT][JSON_FIELD_MESSAGE] =
@@ -101,7 +102,7 @@ void SeatAdjusterApp::onSeatPositionChanged(const velocitas::DataPointReply& dat
     nlohmann::json jsonResponse;
     try {
         const auto seatPositionValue =
-            dataPoints.get(m_vehicleModel->Cabin.Seat.Row1.Pos1.Position)->value();
+            dataPoints.get(m_vehicleModel->Cabin.Seat.Row1.DriverSide.Position)->value();
         jsonResponse[JSON_FIELD_POSITION] = seatPositionValue;
     } catch (std::exception& exception) {
         velocitas::logger().warn("Unable to get Current Seat Position, Exception: {}",

--- a/examples/set-data-points/AppManifest.json
+++ b/examples/set-data-points/AppManifest.json
@@ -5,15 +5,15 @@
         {
             "type": "vehicle-signal-interface",
             "config": {
-                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
+                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v4.0/vss_rel_4.0.json",
                 "datapoints": {
                     "required": [
                         {
-                            "path": "Vehicle.Cabin.Seat.Row1.Pos1.Position",
+                            "path": "Vehicle.Cabin.Seat.Row1.DriverSide.Position",
                             "access": "write"
                         },
                         {
-                            "path": "Vehicle.Cabin.Seat.Row1.Pos2.Position",
+                            "path": "Vehicle.Cabin.Seat.Row1.PassengerSide.Position",
                             "access": "write"
                         },
                         {

--- a/examples/set-data-points/src/SetDataPointsApp.cpp
+++ b/examples/set-data-points/src/SetDataPointsApp.cpp
@@ -51,8 +51,8 @@ public:
             velocitas::logger().info("Setting batch of data points ...");
 
             auto result = Vehicle.setMany()
-                              .add(Vehicle.Cabin.Seat.Row1.Pos1.Position, 1000)
-                              .add(Vehicle.Cabin.Seat.Row1.Pos2.Position, 1000)
+                              .add(Vehicle.Cabin.Seat.Row1.DriverSide.Position, 1000)
+                              .add(Vehicle.Cabin.Seat.Row1.PassengerSide.Position, 1000)
                               .apply()
                               ->await();
 

--- a/sdk/proto/sdv/databroker/v1/broker.proto
+++ b/sdk/proto/sdv/databroker/v1/broker.proto
@@ -84,7 +84,7 @@ message SubscribeReply {
 
 message GetMetadataRequest {
   // Request metadata for a list of data points referenced by their names.
-  // e.g. "Vehicle.Cabin.Seat.Row1.Pos1.Position" or "Vehicle.Speed".
+  // e.g. "Vehicle.Cabin.Seat.Row1.DriverSide.Position" or "Vehicle.Speed".
   //
   // If no names are provided, metadata for all known data points will be
   // returned.

--- a/sdk/proto/sdv/databroker/v1/collector.proto
+++ b/sdk/proto/sdv/databroker/v1/collector.proto
@@ -84,7 +84,7 @@ message RegisterDatapointsRequest {
 
 message RegistrationMetadata {
   // Name of the data point
-  // (e.g. "Vehicle.Cabin.Seat.Row1.Pos1.Position" or "Vehicle.Speed")
+  // (e.g. "Vehicle.Cabin.Seat.Row1.DriverSide.Position" or "Vehicle.Speed")
   string name            = 1;
   DataType data_type     = 2;
   string description     = 3;


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
## Describe your changes

This fixes the examples to use VSS v4.x. Currently, the examples aren't executable with the runtime, because the referenced runtime uses a mock.py using seat signals of VSS 4.0

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas Docs)
