### PR TITLE
Reliable subscriptions by numeric ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The possible names of channel arguments are as they are defined in the above lin
 }
 ```
 
+The buffer size for subscribe requests to the databroker can be set via environment variable `SDV_SUBSCRIBE_BUFFER_SIZE` (default is 0).
+
 ## Documentation
 * [Velocitas Development Model](https://eclipse.dev/velocitas/docs/concepts/development_model/)
 * [Vehicle App SDK Overview](https://eclipse.dev/velocitas/docs/concepts/development_model/vehicle_app_sdk/)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,33 @@ SampleApp::SampleApp()
                                                           "username", "password")) {}
 ```
 
+### Optimizing the gRPC communication channel settings
+
+For possible optimizations of the communication with the KUKSA Databroker you can define setting for 
+the used gRPC channel via so-called ChannelArguments as defined here: https://grpc.github.io/grpc/core/channel__arg__names_8h.html.
+
+You have to define those settings in a JSON based file and pass its filepath via environment varaiable
+`SDV_VDB_CHANNEL_CONFIG_PATH` to the Velocitas SDK based application. The JSON has this structure:
+
+```
+{
+    "channelArguments": {
+        "<name of channel arg>": <value - either string or integer>
+    }
+}
+```
+
+The possible names of channel arguments are as they are defined in the above linked page, for example:
+
+```
+{
+    "channelArguments": {
+        "grpc.http2.lookahead_bytes": 65536,
+        "grpc.default_authority": "Some authority defining string"
+    }
+}
+```
+
 ## Documentation
 * [Velocitas Development Model](https://eclipse.dev/velocitas/docs/concepts/development_model/)
 * [Vehicle App SDK Overview](https://eclipse.dev/velocitas/docs/concepts/development_model/vehicle_app_sdk/)

--- a/sdk/include/sdk/AsyncResult.h
+++ b/sdk/include/sdk/AsyncResult.h
@@ -57,6 +57,8 @@ private:
  */
 struct VoidResult {};
 
+enum class CallState { ONGOING, CANCELING, COMPLETED, FAILED };
+
 /**
  * @brief Single result of an asynchronous operation which provides
  *        an item of type TResultType.
@@ -80,6 +82,7 @@ public:
      * @param result  Result to insert.
      */
     void insertResult(TResultType&& result) {
+        m_callState = CallState::COMPLETED;
         if (m_callback != nullptr) {
             m_callback(result);
         } else {
@@ -94,6 +97,7 @@ public:
      * @param error Status containing error information.
      */
     void insertError(Status&& error) {
+        m_callState = CallState::FAILED;
         if (m_errorCallback != nullptr) {
             m_errorCallback(error);
         } else {
@@ -140,6 +144,9 @@ public:
                 "Invalid usage: Either call await() or register an onResult callback!");
         }
         m_callback = callback;
+        if (m_callState == CallState::COMPLETED) {
+            m_callback(m_result);
+        }
         return this;
     }
 
@@ -152,6 +159,9 @@ public:
      */
     AsyncResult* onError(ErrorCallback_t callback) {
         m_errorCallback = callback;
+        if (m_callState == CallState::FAILED) {
+            m_errorCallback(m_status);
+        }
         return this;
     }
 
@@ -192,6 +202,7 @@ public:
     }
 
 private:
+    CallState        m_callState{CallState::ONGOING};
     TResultType      m_result;
     ResultCallback_t m_callback;
     ErrorCallback_t  m_errorCallback;

--- a/sdk/include/sdk/Job.h
+++ b/sdk/include/sdk/Job.h
@@ -18,11 +18,15 @@
 #define VEHICLE_APP_SDK_JOB_H
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <mutex>
 
 namespace velocitas {
+
+using Clock     = std::chrono::steady_clock;
+using Timepoint = std::chrono::time_point<Clock>;
 
 /**
  * @brief Interface for jobs which can be executed by a worker in the thread pool.
@@ -31,6 +35,10 @@ class IJob {
 public:
     IJob()          = default;
     virtual ~IJob() = default;
+
+    [[nodiscard]] virtual bool isDue() const { return true; }
+
+    [[nodiscard]] virtual Timepoint getTimepointToExecute() const { return {}; }
 
     /**
      * @brief Execute the job.
@@ -58,9 +66,19 @@ using JobPtr_t = std::shared_ptr<IJob>;
  */
 class Job : public IJob {
 public:
-    static JobPtr_t create(std::function<void()> fun) { return std::make_shared<Job>(fun); }
+    static JobPtr_t create(std::function<void()>     fun,
+                           std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) {
+        return std::make_shared<Job>(fun, delay);
+    }
 
-    explicit Job(std::function<void()> fun);
+    explicit Job(std::function<void()>     fun,
+                 std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
+
+    bool isDue() const override {
+        return (m_timepointToExecute == Timepoint()) || (m_timepointToExecute <= Clock::now());
+    }
+
+    Timepoint getTimepointToExecute() const override { return m_timepointToExecute; }
 
     void execute() override;
 
@@ -68,8 +86,11 @@ public:
 
 private:
     std::function<void()> m_fun;
+    Timepoint             m_timepointToExecute;
     mutable std::mutex    m_terminationMutex;
 };
+
+bool lowerJobPriority(const JobPtr_t& left, const JobPtr_t& right);
 
 /**
  * @brief A recurring job which can be cancelled manually.

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(${TARGET_NAME}
     sdk/pubsub/MqttPubSubClient.cpp
     sdk/vdb/DataPointBatch.cpp
     sdk/vdb/IVehicleDataBrokerClient.cpp
+    sdk/vdb/grpc/common/ChannelConfiguration.cpp
     sdk/vdb/grpc/common/TypeConversions.cpp
     sdk/vdb/grpc/kuksa_val_v2/BrokerAsyncGrpcFacade.cpp
     sdk/vdb/grpc/kuksa_val_v2/BrokerClient.cpp

--- a/sdk/src/sdk/Job.cpp
+++ b/sdk/src/sdk/Job.cpp
@@ -18,8 +18,16 @@
 
 namespace velocitas {
 
-Job::Job(std::function<void()> fun)
-    : m_fun(std::move(fun)) {}
+bool lowerJobPriority(const JobPtr_t& left, const JobPtr_t& right) {
+    return left->getTimepointToExecute() > right->getTimepointToExecute();
+}
+
+Job::Job(std::function<void()> fun, std::chrono::milliseconds delay)
+    : m_fun(std::move(fun)) {
+    if (delay > std::chrono::milliseconds::zero()) {
+        m_timepointToExecute = Clock::now() + delay;
+    }
+}
 
 void Job::waitForTermination() const { std::lock_guard lock(m_terminationMutex); }
 

--- a/sdk/src/sdk/ThreadPool.cpp
+++ b/sdk/src/sdk/ThreadPool.cpp
@@ -17,10 +17,13 @@
 #include "sdk/ThreadPool.h"
 #include "sdk/Logger.h"
 
+#include <cassert>
+
 namespace velocitas {
 
 ThreadPool::ThreadPool(size_t numWorkerThreads)
-    : m_workerThreads{numWorkerThreads} {
+    : m_jobs(&lowerJobPriority)
+    , m_workerThreads{numWorkerThreads} {
     for (size_t i = 0; i < numWorkerThreads; ++i) {
         m_workerThreads[i] = std::thread([this]() { threadLoop(); });
     }
@@ -33,8 +36,8 @@ ThreadPool::~ThreadPool() {
     {
         std::lock_guard lock{m_queueMutex};
         m_isRunning = false;
-        // empty the job queue (std::queue does not offer a clear function)
-        std::queue<JobPtr_t>().swap(m_jobs);
+        // empty the job queue (std::priority_queue does not offer a clear function)
+        QueueType().swap(m_jobs);
     }
     m_cv.notify_all();
 
@@ -51,38 +54,59 @@ std::shared_ptr<ThreadPool> ThreadPool::getInstance() {
 size_t ThreadPool::getNumWorkerThreads() const { return m_workerThreads.size(); }
 
 void ThreadPool::enqueue(JobPtr_t job) {
-    std::lock_guard<std::mutex> lock(m_queueMutex);
-    m_jobs.emplace(std::move(job));
-    m_cv.notify_one();
+    if (job) {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        m_jobs.push(std::move(job));
+        m_cv.notify_one();
+    } else {
+        logger().error("[ThreadPool::enqueue] Ignoring nullptr Job!");
+        assert(job);
+    }
 }
+
+JobPtr_t ThreadPool::getNextExecutableJob() {
+    JobPtr_t                    job;
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    if (!m_jobs.empty() && m_jobs.top()->isDue()) {
+        job = m_jobs.top();
+        m_jobs.pop();
+    }
+    return job;
+}
+
+void ThreadPool::waitForPotentiallyExecutableJob() const {
+    std::unique_lock<std::mutex> lock(m_queueMutex);
+    if (m_jobs.empty()) {
+        m_cv.wait(lock, [this] { return !m_jobs.empty() || !m_isRunning; });
+    } else {
+        auto timepointToExecuteNextJob = m_jobs.top()->getTimepointToExecute();
+        m_cv.wait_until(lock, timepointToExecuteNextJob);
+    }
+}
+
+namespace {
+void executeJob(JobPtr_t job) {
+    try {
+        job->execute();
+    } catch (const std::exception& e) {
+        logger().error("[ThreadPool] Uncaught exception during job execution: " +
+                       std::string(e.what()));
+    } catch (...) {
+        logger().error(std::string("[ThreadPool] Uncaught unknown exception during job execution"));
+    }
+}
+} // namespace
 
 void ThreadPool::threadLoop() {
     while (m_isRunning) {
-        JobPtr_t job;
-        {
-            std::lock_guard<std::mutex> lock(m_queueMutex);
-            if (!m_jobs.empty()) {
-                job = m_jobs.front();
-                m_jobs.pop();
-            }
-        }
-
+        JobPtr_t job = getNextExecutableJob();
         if (job) {
-            try {
-                job->execute();
-                if (job->shallRecur()) {
-                    enqueue(job);
-                }
-            } catch (const std::exception& e) {
-                logger().error("[ThreadPool] Uncaught exception in job execution: " +
-                               std::string(e.what()));
-            } catch (...) {
-                logger().error(
-                    std::string("[ThreadPool] Uncaught unknown exception in job execution"));
+            executeJob(job);
+            if (job->shallRecur()) {
+                enqueue(job);
             }
         } else {
-            std::unique_lock<std::mutex> lock(m_queueMutex);
-            m_cv.wait(lock, [this] { return !m_jobs.empty() || !m_isRunning; });
+            waitForPotentiallyExecutableJob();
         }
     }
 }

--- a/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.cpp
+++ b/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024-2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License, Version 2.0 which is available at

--- a/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.cpp
+++ b/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.cpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ChannelConfiguration.h"
+
+#include "sdk/Logger.h"
+#include "sdk/Utils.h"
+
+#include <fstream>
+#include <grpcpp/support/channel_arguments.h>
+#include <nlohmann/json.hpp>
+
+extern char** environ;
+
+namespace velocitas {
+
+namespace {
+constexpr char const* ENV_VAR_CHANNEL_CONFIG = "SDV_VDB_CHANNEL_CONFIG_PATH";
+
+constexpr char const* JSON_CHANNEL_ARGS_KEY = "channelArguments";
+} // namespace
+
+grpc::ChannelArguments getChannelArguments() {
+    grpc::ChannelArguments chArgs;
+
+    std::string chConfigFilepath = getEnvVar(ENV_VAR_CHANNEL_CONFIG);
+    if (!chConfigFilepath.empty()) {
+        auto ifs = std::ifstream(chConfigFilepath);
+        if (ifs.is_open()) {
+            try {
+                velocitas::logger().info("Reading channel configuration from file {}.",
+                                         chConfigFilepath);
+                const auto  config      = nlohmann::json::parse(ifs);
+                const auto& channelArgs = config[JSON_CHANNEL_ARGS_KEY];
+                for (const auto& channelArg : channelArgs.items()) {
+                    if (channelArg.value().is_number_integer()) {
+                        chArgs.SetInt(channelArg.key(), channelArg.value());
+                    } else if (channelArg.value().is_string()) {
+                        chArgs.SetString(channelArg.key(), channelArg.value());
+                    } else {
+                        velocitas::logger().warn("Ignoring channel argument {} - unknown type.",
+                                                 channelArg.key());
+                    }
+                }
+            } catch (const nlohmann::json::exception& ex) {
+                velocitas::logger().warn("Error reading channel configuration file {}.",
+                                         chConfigFilepath);
+            }
+        } else {
+            velocitas::logger().warn("Cannot open channel configuration file {}.",
+                                     chConfigFilepath);
+        }
+    }
+
+    return chArgs;
+}
+
+} // namespace velocitas

--- a/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.h
+++ b/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024-2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License, Version 2.0 which is available at

--- a/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.h
+++ b/sdk/src/sdk/vdb/grpc/common/ChannelConfiguration.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef VEHICLE_APP_SDK_VDB_GRPC_COMMON_CHANNELCONFIGURATION_H
+#define VEHICLE_APP_SDK_VDB_GRPC_COMMON_CHANNELCONFIGURATION_H
+
+namespace grpc {
+class ChannelArguments;
+}
+
+namespace velocitas {
+
+grpc::ChannelArguments getChannelArguments();
+
+} // namespace velocitas
+
+#endif // VEHICLE_APP_SDK_VDB_GRPC_COMMON_CHANNELCONFIGURATION_H

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerAsyncGrpcFacade.h
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerAsyncGrpcFacade.h
@@ -40,14 +40,19 @@ public:
                    std::function<void(const kuksa::val::v2::GetValuesResponse& reply)> replyHandler,
                    std::function<void(const grpc::Status& status)> errorHandler);
 
-    void
-    Subscribe(kuksa::val::v2::SubscribeRequest                                     request,
-              std::function<void(const kuksa::val::v2::SubscribeResponse& update)> updateHandler,
-              std::function<void(const grpc::Status& status)>                      errorHandler);
+    void SubscribeById(
+        kuksa::val::v2::SubscribeByIdRequest                                     request,
+        std::function<void(const kuksa::val::v2::SubscribeByIdResponse& update)> updateHandler,
+        std::function<void(const grpc::Status& status)>                          errorHandler);
 
     void BatchActuate(
         kuksa::val::v2::BatchActuateRequest                                    request,
         std::function<void(const kuksa::val::v2::BatchActuateResponse& reply)> replyHandler,
+        std::function<void(const grpc::Status& status)>                        errorHandler);
+
+    void ListMetadata(
+        kuksa::val::v2::ListMetadataRequest                                    request,
+        std::function<void(const kuksa::val::v2::ListMetadataResponse& reply)> replyHandler,
         std::function<void(const grpc::Status& status)>                        errorHandler);
 
 private:

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerAsyncGrpcFacade.h
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerAsyncGrpcFacade.h
@@ -55,31 +55,6 @@ public:
         std::function<void(const kuksa::val::v2::ListMetadataResponse& reply)> replyHandler,
         std::function<void(const grpc::Status& status)>                        errorHandler);
 
-    template <typename TRequest, typename TResponse, typename TFunction>
-    void doSingleReponseCall(TRequest                                        request,
-                             std::function<void(const TResponse& response)>  responseHandler,
-                             std::function<void(const grpc::Status& status)> errorHandler) {
-        auto callData       = std::make_shared<GrpcSingleResponseCall<TRequest, TResponse>>();
-        callData->m_request = std::move(request);
-        applyContextModifier(*callData);
-
-        auto grpcResultHandler = [callData, responseHandler, errorHandler](grpc::Status status) {
-            try {
-                if (status.ok()) {
-                    responseHandler(callData->m_response);
-                } else {
-                    errorHandler(status);
-                };
-            } catch (std::exception& e) {
-                logger().error("GRPC: Exception occurred during \"BatchActuate\": {}", e.what());
-            }
-            callData->m_isComplete = true;
-        };
-        addActiveCall(callData);
-        TFunction(&callData->m_context, &callData->m_request, &callData->m_response,
-                  grpcResultHandler);
-    }
-
 private:
     std::unique_ptr<kuksa::val::v2::VAL::StubInterface> m_stub;
 };

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.cpp
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.cpp
@@ -19,6 +19,7 @@
 #include "sdk/DataPointValue.h"
 #include "sdk/Logger.h"
 #include "sdk/middleware/Middleware.h"
+#include "sdk/vdb/grpc/common/ChannelConfiguration.h"
 #include "sdk/vdb/grpc/kuksa_val_v2/BrokerAsyncGrpcFacade.h"
 #include "sdk/vdb/grpc/kuksa_val_v2/TypeConversions.h"
 
@@ -46,8 +47,8 @@ int assertProtobufArrayLimits(size_t numElements) {
 
 BrokerClient::BrokerClient(const std::string& vdbAddress, const std::string& vdbServiceName) {
     logger().info("Connecting to data broker service '{}' via '{}'", vdbServiceName, vdbAddress);
-    m_asyncBrokerFacade = std::make_shared<BrokerAsyncGrpcFacade>(
-        grpc::CreateChannel(vdbAddress, grpc::InsecureChannelCredentials()));
+    m_asyncBrokerFacade = std::make_shared<BrokerAsyncGrpcFacade>(grpc::CreateCustomChannel(
+        vdbAddress, grpc::InsecureChannelCredentials(), getChannelArguments()));
     Middleware::Metadata metadata = Middleware::getInstance().getMetadata(vdbServiceName);
     m_asyncBrokerFacade->setContextModifier([metadata](auto& context) {
         for (auto metadatum : metadata) {

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.cpp
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.cpp
@@ -243,7 +243,6 @@ public:
             logger().error("Requesting metadata of signal '{}' results in metadata for {} signals "
                            "returned. Assuming the signal as 'unknown'.",
                            *m_currentPath, response.metadata_size());
-            assert(response.metadata_size() == 1);
             onMetadataError(grpc::Status(grpc::StatusCode::NOT_FOUND, ""));
         }
     }

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.h
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.h
@@ -21,9 +21,14 @@
 
 #include <memory>
 
-namespace velocitas::kuksa_val_v2 {
+namespace velocitas {
+
+class GrpcClient;
+
+namespace kuksa_val_v2 {
 
 class BrokerAsyncGrpcFacade;
+class MetadataStore;
 
 /**
  * Provides the Graph API to access vehicle signals via the kuksa.val.v2 API
@@ -50,8 +55,11 @@ public:
 
 private:
     std::shared_ptr<BrokerAsyncGrpcFacade> m_asyncBrokerFacade;
+    std::shared_ptr<MetadataStore>         m_metadataStore;
+    std::unique_ptr<GrpcClient>            m_activeCalls;
 };
 
-} // namespace velocitas::kuksa_val_v2
+} // namespace kuksa_val_v2
+} // namespace velocitas
 
 #endif // VEHICLE_APP_SDK_VDB_GRPC_KUKSA_VAL_V2_BROKERCLIENT_H

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/TypeConversions.cpp
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/TypeConversions.cpp
@@ -231,7 +231,7 @@ convertFromGrpcDataPoint(const std::string& path, const kuksa::val::v2::Datapoin
 static const std::string SELECT_STATEMENT{"SELECT "}; // NOLINT(runtime/string)
 static const std::string WHERE_STATEMENT{" WHERE "};  // NOLINT(runtime/string)
 
-void parseQueryIntoRequest(kuksa::val::v2::SubscribeRequest& request, const std::string& query) {
+std::vector<std::string> parseQuery(const std::string& query) {
     if (query.find(SELECT_STATEMENT) != 0) {
         throw std::runtime_error("Mallformed query not starting with \"SELECT \"!");
     }
@@ -240,6 +240,7 @@ void parseQueryIntoRequest(kuksa::val::v2::SubscribeRequest& request, const std:
             "Queries (containing WHERE clauses) not allowd with kuksa.val.v2 API!");
     }
 
+    std::vector<std::string> signalPaths;
     for (std::string::size_type first{SELECT_STATEMENT.size()}, last{};
          (first = query.find_first_not_of(' ', first)) != std::string::npos; first = last + 1) {
         last = query.find_first_of(", ", first + 1);
@@ -247,12 +248,13 @@ void parseQueryIntoRequest(kuksa::val::v2::SubscribeRequest& request, const std:
             last = query.length();
         }
         std::string path = query.substr(first, last - first);
-        request.add_signal_paths(std::move(path));
+        signalPaths.emplace_back(std::move(path));
     }
 
-    if (request.signal_paths().empty()) {
+    if (signalPaths.empty()) {
         throw std::runtime_error("Mallformed query selecting no signals!");
     }
+    return signalPaths;
 }
 
 } // namespace velocitas::kuksa_val_v2

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/TypeConversions.h
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/TypeConversions.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace velocitas::kuksa_val_v2 {
 
@@ -35,7 +36,7 @@ std::shared_ptr<DataPointValue> convertFromGrpcValue(const std::string&         
 std::shared_ptr<DataPointValue>
 convertFromGrpcDataPoint(const std::string& path, const kuksa::val::v2::Datapoint& grpcDataPoint);
 
-void parseQueryIntoRequest(kuksa::val::v2::SubscribeRequest& request, const std::string& query);
+std::vector<std::string> parseQuery(const std::string& query);
 
 } // namespace velocitas::kuksa_val_v2
 

--- a/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerAsyncGrpcFacade.cpp
+++ b/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerAsyncGrpcFacade.cpp
@@ -43,7 +43,7 @@ void BrokerAsyncGrpcFacade::GetDatapoints(
     const auto grpcResultHandler = [callData, replyHandler, errorHandler](grpc::Status status) {
         try {
             if (status.ok()) {
-                replyHandler(callData->m_reply);
+                replyHandler(callData->m_response);
             } else {
                 errorHandler(status);
             };
@@ -55,8 +55,8 @@ void BrokerAsyncGrpcFacade::GetDatapoints(
 
     addActiveCall(callData);
 
-    m_stub->async()->GetDatapoints(&callData->m_context, &callData->m_request, &callData->m_reply,
-                                   grpcResultHandler);
+    m_stub->async()->GetDatapoints(&callData->m_context, &callData->m_request,
+                                   &callData->m_response, grpcResultHandler);
 }
 
 void BrokerAsyncGrpcFacade::SetDatapoints(
@@ -76,7 +76,7 @@ void BrokerAsyncGrpcFacade::SetDatapoints(
     auto grpcResultHandler = [callData, replyHandler, errorHandler](grpc::Status status) {
         try {
             if (status.ok()) {
-                replyHandler(callData->m_reply);
+                replyHandler(callData->m_response);
             } else {
                 errorHandler(status);
             };
@@ -88,8 +88,8 @@ void BrokerAsyncGrpcFacade::SetDatapoints(
 
     addActiveCall(callData);
 
-    m_stub->async()->SetDatapoints(&callData->m_context, &callData->m_request, &callData->m_reply,
-                                   grpcResultHandler);
+    m_stub->async()->SetDatapoints(&callData->m_context, &callData->m_request,
+                                   &callData->m_response, grpcResultHandler);
 }
 
 void BrokerAsyncGrpcFacade::Subscribe(

--- a/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerClient.cpp
+++ b/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerClient.cpp
@@ -18,7 +18,6 @@
 
 #include "sdk/DataPointValue.h"
 #include "sdk/Exceptions.h"
-#include "sdk/Job.h"
 #include "sdk/Logger.h"
 
 #include "sdk/middleware/Middleware.h"

--- a/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerClient.cpp
+++ b/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerClient.cpp
@@ -22,6 +22,7 @@
 #include "sdk/Logger.h"
 
 #include "sdk/middleware/Middleware.h"
+#include "sdk/vdb/grpc/common/ChannelConfiguration.h"
 #include "sdk/vdb/grpc/sdv_databroker_v1/BrokerAsyncGrpcFacade.h"
 #include "sdk/vdb/grpc/sdv_databroker_v1/GrpcDataPointValueProvider.h"
 
@@ -37,8 +38,8 @@ namespace velocitas::sdv_databroker_v1 {
 
 BrokerClient::BrokerClient(const std::string& vdbAddress, const std::string& vdbServiceName) {
     logger().info("Connecting to data broker service '{}' via '{}'", vdbServiceName, vdbAddress);
-    m_asyncBrokerFacade = std::make_shared<BrokerAsyncGrpcFacade>(
-        grpc::CreateChannel(vdbAddress, grpc::InsecureChannelCredentials()));
+    m_asyncBrokerFacade = std::make_shared<BrokerAsyncGrpcFacade>(grpc::CreateCustomChannel(
+        vdbAddress, grpc::InsecureChannelCredentials(), getChannelArguments()));
     Middleware::Metadata metadata = Middleware::getInstance().getMetadata(vdbServiceName);
     m_asyncBrokerFacade->setContextModifier([metadata](auto& context) {
         for (auto metadatum : metadata) {

--- a/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerClient.h
+++ b/sdk/src/sdk/vdb/grpc/sdv_databroker_v1/BrokerClient.h
@@ -23,11 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace velocitas {
-
-class RecurringJob;
-
-namespace sdv_databroker_v1 {
+namespace velocitas::sdv_databroker_v1 {
 
 class BrokerAsyncGrpcFacade;
 
@@ -59,7 +55,6 @@ private:
     std::shared_ptr<BrokerAsyncGrpcFacade> m_asyncBrokerFacade;
 };
 
-} // namespace sdv_databroker_v1
-} // namespace velocitas
+} // namespace velocitas::sdv_databroker_v1
 
 #endif // VEHICLE_APP_SDK_BROKERCLIENT_H

--- a/sdk/tests/unit/ThreadPool_tests.cpp
+++ b/sdk/tests/unit/ThreadPool_tests.cpp
@@ -171,16 +171,6 @@ TEST_F(Test_ThreadPool, stopExecutingOneJob_queuedJob_jobExecuted) {
     EXPECT_TRUE(m_fakeJobs.back()->waitForExecution());
 }
 
-TEST_F(Test_ThreadPool,
-       stopExecutingJob_queuedEmptyJobAndRealJob_emptyJobIgnoredAndRealJobExectuted) {
-    ASSERT_TRUE(occupyAllWorkers());
-    m_pool->enqueue(nullptr);
-    ASSERT_FALSE(createAndExecuteJob(0ms));
-
-    ASSERT_TRUE(finishJob(m_fakeJobs.front()));
-    EXPECT_TRUE(m_fakeJobs.back()->waitForExecution());
-}
-
 TEST_F(Test_ThreadPool, destroyThreadPool_occupiedWorkers_waitForWorkersFinished) {
     ASSERT_TRUE(occupyAllWorkers());
 

--- a/sdk/tests/unit/vdb/grpc/kuksa_val_v2/TypeConversions_tests.cpp
+++ b/sdk/tests/unit/vdb/grpc/kuksa_val_v2/TypeConversions_tests.cpp
@@ -204,53 +204,49 @@ TEST(Test_TypeConversion, convertFromGrpcValue__allMembersSetCorrectly) {
     testValueConversion<std::vector<std::string>>({"", "hello", "world", "!"});
 }
 
-TEST(Test_TypeConversion, parseQueryIntoRequest_emptyQuery_runtimeError) {
-    kuksa::val::v2::SubscribeRequest request;
-    EXPECT_THROW(kuksa_val_v2::parseQueryIntoRequest(request, ""), std::runtime_error);
+TEST(Test_TypeConversion, parseQuery_emptyQuery_runtimeError) {
+    EXPECT_THROW(kuksa_val_v2::parseQuery(""), std::runtime_error);
 }
 
-TEST(Test_TypeConversion, parseQueryIntoRequest_queryWithoutSelect_runtimeError) {
-    kuksa::val::v2::SubscribeRequest request;
-    EXPECT_THROW(kuksa_val_v2::parseQueryIntoRequest(request, "Vehicle.Speed"), std::runtime_error);
+TEST(Test_TypeConversion, parseQuery_queryWithoutSelect_runtimeError) {
+    EXPECT_THROW(kuksa_val_v2::parseQuery("Vehicle.Speed"), std::runtime_error);
 }
 
-TEST(Test_TypeConversion, parseQueryIntoRequest_queryWithoutSignals_runtimeError) {
-    kuksa::val::v2::SubscribeRequest request;
-    EXPECT_THROW(kuksa_val_v2::parseQueryIntoRequest(request, "SELECT "), std::runtime_error);
+TEST(Test_TypeConversion, parseQuery_queryWithoutSignals_runtimeError) {
+    EXPECT_THROW(kuksa_val_v2::parseQuery("SELECT "), std::runtime_error);
 }
 
-TEST(Test_TypeConversion, parseQueryIntoRequest_queryWithSingleSignal_signalPathIsCorrect) {
+TEST(Test_TypeConversion, parseQuery_queryWithSingleSignal_signalPathIsCorrect) {
     const Vehicle     vehicle;
     const std::string query = QueryBuilder::select(vehicle.Speed).build();
 
-    kuksa::val::v2::SubscribeRequest request;
-    EXPECT_NO_THROW(kuksa_val_v2::parseQueryIntoRequest(request, query));
+    std::vector<std::string> signalPaths;
+    EXPECT_NO_THROW(signalPaths = kuksa_val_v2::parseQuery(query));
 
-    ASSERT_EQ(1, request.signal_paths().size());
-    EXPECT_EQ(vehicle.Speed.getPath(), request.signal_paths()[0]);
+    ASSERT_EQ(1, signalPaths.size());
+    EXPECT_EQ(vehicle.Speed.getPath(), signalPaths[0]);
 }
 
-TEST(Test_TypeConversion, parseQueryIntoRequest_queryWithMultipleSignals_signalPathsAreCorrect) {
+TEST(Test_TypeConversion, parseQuery_queryWithMultipleSignals_signalPathsAreCorrect) {
     Vehicle           vehicle;
     const std::string query =
         QueryBuilder::select({vehicle.Speed, vehicle.Cabin.Seat.Row1.DriverSide.Position,
                               vehicle.Cabin.Seat.Row1.PassengerSide.Position})
             .build();
 
-    kuksa::val::v2::SubscribeRequest request;
-    EXPECT_NO_THROW(kuksa_val_v2::parseQueryIntoRequest(request, query));
+    std::vector<std::string> signalPaths;
+    EXPECT_NO_THROW(signalPaths = kuksa_val_v2::parseQuery(query));
 
-    ASSERT_EQ(3, request.signal_paths().size());
-    EXPECT_EQ(vehicle.Speed.getPath(), request.signal_paths()[0]);
-    EXPECT_EQ(vehicle.Cabin.Seat.Row1.DriverSide.Position.getPath(), request.signal_paths()[1]);
-    EXPECT_EQ(vehicle.Cabin.Seat.Row1.PassengerSide.Position.getPath(), request.signal_paths()[2]);
+    ASSERT_EQ(3, signalPaths.size());
+    EXPECT_EQ(vehicle.Speed.getPath(), signalPaths[0]);
+    EXPECT_EQ(vehicle.Cabin.Seat.Row1.DriverSide.Position.getPath(), signalPaths[1]);
+    EXPECT_EQ(vehicle.Cabin.Seat.Row1.PassengerSide.Position.getPath(), signalPaths[2]);
 }
 
-TEST(Test_TypeConversion, parseQueryIntoRequest_queryWithWhereClause_runtimeError) {
+TEST(Test_TypeConversion, parseQuery_queryWithWhereClause_runtimeError) {
     const Vehicle     vehicle;
     const std::string query =
         QueryBuilder::select(vehicle.Speed).where(vehicle.Speed).gt(30).build();
 
-    kuksa::val::v2::SubscribeRequest request;
-    EXPECT_THROW(kuksa_val_v2::parseQueryIntoRequest(request, query), std::runtime_error);
+    EXPECT_THROW(kuksa_val_v2::parseQuery(query), std::runtime_error);
 }


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
## Describe your changes

This implements subscribing to signals via the numeric id. 
This is implemented on top of the custom channel arguments PR.
Steps during subscribe:
- Fetch metadata for each signal to be subscribed and which is net yet cached in the MetadataStore.
  This is done in an asynchronous loop for each signal separately - due to limitations of the `ListMetadata` request of the broker.
  The returned metadata (currently just path and id) is added to the MetadataStore.
- Finally call `subscribeById` request using the cached ids.
- Cached ids are invalidated if an ongoing subscription gRPC-Call is terminated by the databroker with a status code of "unavailable" or "ok". (The expectation is that ongoing subscriptions should only be cancelled by consumers in regular cases.)

Reliable subscriptions:
- If existing subscriptions are terminated from databroker side, i.e. because the broker gets unavailable, Velocitas SDK-.based apps will automatically try to renew all existing subscriptions.
- This is transparent to the user code of an app: Re-subscription is handled by the SDK part. Apps will recognize unavailability of the databroker by getting an update notification for all subscribed signals to be currently not available, i.e. not having a valid value during that time.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas Docs)
