### PR TITLE
VehicleApps: Make usage/connection to PubSub (MQTT) optional

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -13,17 +13,17 @@
 |distlib|0.3.9|Python Software Foundation License|
 |distro|1.8.0|Apache 2.0|
 |fasteners|0.19|Apache 2.0|
-|filelock|3.17.0|The Unlicense (Unlicense)|
+|filelock|3.18.0|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.6.8|MIT|
+|identify|2.6.9|MIT|
 |idna|3.10|BSD|
-|jinja2|3.1.5|BSD|
+|jinja2|3.1.6|BSD|
 |lxml|5.3.1|New BSD|
 |MarkupSafe|3.0.2|BSD|
 |node-semver|0.6.1|MIT|
 |nodeenv|1.9.1|BSD|
 |patch-ng|1.17.4|MIT|
-|platformdirs|4.3.6|MIT|
+|platformdirs|4.3.7|MIT|
 |pluginbase|1.0.1|BSD|
 |pre-commit|3.5.0|MIT|
 |pygments|2.19.1|Simplified BSD|
@@ -34,7 +34,7 @@
 |six|1.16.0|MIT|
 |tqdm|4.67.1|MIT<br/>Mozilla Public License 2.0 (MPL 2.0)|
 |urllib3|1.26.20|MIT|
-|virtualenv|20.29.2|MIT|
+|virtualenv|20.29.3|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/examples/performance-subscribe/src/PerformanceTestApp.cpp
+++ b/examples/performance-subscribe/src/PerformanceTestApp.cpp
@@ -44,8 +44,7 @@ template <typename TTimeBase> TTimeBase getTimestamp() {
 } // anonymous namespace
 
 PerformanceTestApp::PerformanceTestApp(std::vector<std::string> signalList)
-    : VehicleApp(velocitas::IVehicleDataBrokerClient::createInstance("vehicledatabroker"),
-                 velocitas::IPubSubClient::createInstance("PerformanceTestApp"))
+    : VehicleApp(velocitas::IVehicleDataBrokerClient::createInstance("vehicledatabroker"))
     , m_signalList{std::move(signalList)} {}
 
 void PerformanceTestApp::onStart() {

--- a/examples/set-data-points/src/SetDataPointsApp.cpp
+++ b/examples/set-data-points/src/SetDataPointsApp.cpp
@@ -31,8 +31,7 @@ namespace example {
 class SetDataPointsApp : public velocitas::VehicleApp {
 public:
     SetDataPointsApp()
-        : VehicleApp(velocitas::IVehicleDataBrokerClient::createInstance("vehicledatabroker"),
-                     velocitas::IPubSubClient::createInstance("SetDataPointsApp")) {}
+        : VehicleApp(velocitas::IVehicleDataBrokerClient::createInstance("vehicledatabroker")) {}
 
     void onStart() override {
         // set a single data point

--- a/sdk/include/sdk/VehicleApp.h
+++ b/sdk/include/sdk/VehicleApp.h
@@ -42,10 +42,11 @@ public:
      * @brief Construct a new Vehicle App object.
      *
      * @param vdbClient     The vehicle data broker client to use.
-     * @param pubSubClient  The pubsub client to use.
+     * @param pubSubClient  The pubsub client to use. Using a pubsub client is optional.
+     *                      If passing a nullptr, the app will not use/offer pubsub.
      */
     explicit VehicleApp(std::shared_ptr<IVehicleDataBrokerClient> vdbClient,
-                        std::shared_ptr<IPubSubClient>            pubSubClient);
+                        std::shared_ptr<IPubSubClient>            pubSubClient = {});
 
     virtual ~VehicleApp() = default;
 
@@ -138,7 +139,7 @@ protected:
     /**
      * @brief Get the Pub Sub Client object
      *
-     * @return std::shared_ptr<IPubSubClient>
+     * @return std::shared_ptr<IPubSubClient>; will be nullptr if no PubSubClient was instantiated
      */
     std::shared_ptr<IPubSubClient> getPubSubClient();
 


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
## Describe your changes

The usage of a PubSub client within VehicleApps in now optional, i.e. apps are no longer "forced" to have a MQTT broker up and running even if not using pubsub in their code.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas Docs)
