### PR TITLE
Fix await setting datapoints blocking forever in success case

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -4,37 +4,37 @@
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
 |bottle|0.12.25|MIT|
-|certifi|2024.8.30|Mozilla Public License 2.0|
+|certifi|2025.1.31|Mozilla Public License 2.0|
 |cfgv|3.4.0|MIT|
-|charset-normalizer|3.4.0|MIT|
+|charset-normalizer|3.4.1|MIT|
 |colorama|0.4.6|BSD|
-|conan|1.63.0|MIT|
+|conan|1.66.0|MIT|
 |cpplint|1.6.1|New BSD|
 |distlib|0.3.9|Python Software Foundation License|
 |distro|1.8.0|Apache 2.0|
 |fasteners|0.19|Apache 2.0|
-|filelock|3.16.1|The Unlicense (Unlicense)|
+|filelock|3.18.0|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.6.3|MIT|
+|identify|2.6.9|MIT|
 |idna|3.10|BSD|
-|jinja2|3.1.4|BSD|
-|lxml|5.3.0|New BSD|
+|jinja2|3.1.6|BSD|
+|lxml|5.3.2|New BSD|
 |MarkupSafe|3.0.2|BSD|
 |node-semver|0.6.1|MIT|
 |nodeenv|1.9.1|BSD|
 |patch-ng|1.17.4|MIT|
-|platformdirs|4.3.6|MIT|
+|platformdirs|4.3.7|MIT|
 |pluginbase|1.0.1|BSD|
 |pre-commit|3.5.0|MIT|
-|pygments|2.18.0|Simplified BSD|
-|PyJWT|2.10.0|MIT|
+|pygments|2.19.1|Simplified BSD|
+|PyJWT|2.10.1|MIT|
 |python-dateutil|2.9.0.post0|Apache 2.0<br/>BSD|
 |PyYAML|6.0.2|MIT|
 |requests|2.32.3|Apache 2.0|
 |six|1.16.0|MIT|
 |tqdm|4.67.1|MIT<br/>Mozilla Public License 2.0 (MPL 2.0)|
 |urllib3|1.26.20|MIT|
-|virtualenv|20.28.0|MIT|
+|virtualenv|20.30.0|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.cpp
+++ b/sdk/src/sdk/vdb/grpc/kuksa_val_v2/BrokerClient.cpp
@@ -117,7 +117,9 @@ BrokerClient::setDatapoints(const std::vector<std::unique_ptr<DataPointValue>>& 
     m_asyncBrokerFacade->BatchActuate(
         std::move(batchRequest),
         [result](const kuksa::val::v2::BatchActuateResponse& reply) {
+            std::ignore = reply;
             // Everything went fine, return empty map
+            result->insertResult(SetErrorMap_t());
         },
         [result](auto status) {
             result->insertError(


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
## Describe your changes

This is a **hotfix for the version 0.6.0** fixing the blocking await on setting datapoints in success case.
**Do not rebase or merge!**

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas Docs)
